### PR TITLE
security: adiciona expiração ao token JWT - Fixes #1

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,4 @@
 # DB_USER= db_user_mongodb
 # DB_PASS= db_password_mongodb
 # SECRET= hash
+# JWT_EXPIRES_IN= dias

--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -80,7 +80,9 @@ exports.login = async (req, res) => {
 
   try {
     const secret = process.env.SECRET;
-    const token = jwt.sign({ id: user._id }, secret);
+    const token = jwt.sign({ userId: user._id }, process.env.JWT_SECRET, {
+      expiresIn: process.env.JWT_EXPIRES_IN || "7d",
+    });
 
     res.status(200).json({
       message: "Autenticação realizada com sucesso",

--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -80,7 +80,7 @@ exports.login = async (req, res) => {
 
   try {
     const secret = process.env.SECRET;
-    const token = jwt.sign({ userId: user._id }, process.env.JWT_SECRET, {
+    const token = jwt.sign({ userId: user._id }, secret, {
       expiresIn: process.env.JWT_EXPIRES_IN || "7d",
     });
 

--- a/middleware/checkToken.js
+++ b/middleware/checkToken.js
@@ -12,11 +12,31 @@ function checkToken(req, res, next) {
 
   try {
     const secret = process.env.SECRET;
-    jwt.verify(token, secret);
+    const decoded = jwt.verify(token, secret);
+    
+    // Adiciona as informações do usuário na requisição
+    req.userId = decoded.userId;
+    req.user = decoded;
+    
     next();
   } catch (error) {
-    res.status(400).json({
-      message: "Token inválido!",
+    // Trata especificamente token expirado
+    if (error.name === "TokenExpiredError") {
+      return res.status(401).json({
+        message: "Token expirado!",
+      });
+    }
+    
+    // Trata token inválido
+    if (error.name === "JsonWebTokenError") {
+      return res.status(401).json({
+        message: "Token inválido!",
+      });
+    }
+    
+    // Outros erros
+    return res.status(400).json({
+      message: "Erro na autenticação",
     });
   }
 }


### PR DESCRIPTION
## Descrição

Implementa expiração de tokens JWT para melhorar a segurança da aplicação.

## Issue Relacionada

Fixes #1

## Mudanças

- Adiciona parâmetro `expiresIn` na geração do token
- Adiciona variável `JWT_EXPIRES_IN` no .env.example
- Token expira em 7 dias por padrão
- Adiciona variável JWT_EXPIRES_IN no .env.example
- Atualiza middleware para tratar tokens expirados

## Como Testar

1. Faça login na aplicação
2. O token gerado agora terá expiração
3. Após 7 dias, o token será inválido